### PR TITLE
Updated AbstractBitcoinNetParams::bitsToTarget to match spec.

### DIFF
--- a/core/src/main/java/org/bitcoinj/params/AbstractBitcoinNetParams.java
+++ b/core/src/main/java/org/bitcoinj/params/AbstractBitcoinNetParams.java
@@ -188,27 +188,19 @@ public abstract class AbstractBitcoinNetParams extends NetworkParameters {
     }
 
     private static BigInteger bitsToTarget(int bits) {
-        int mantissa = bits & 0x007fffff;
-        boolean isNegative = (bits & 0x00800000) != 0;
-        int exponent = bits>>24;
-        assert exponent <= 0x1d;
-        BigInteger bn;
+        int size = bits >> 24;
+        assert size <= 0x1d;
 
-        if(exponent <= 3) {
-            mantissa >>= 8 * (3 - exponent);
-            bn = BigInteger.valueOf((long) mantissa);
-            System.out.println("exponent <= 3");
+        int word = bits & 0x00ffffff;
+        assert 0x8000 <= word;
+        assert word <= 0x7fffff;
+
+        if (size <= 3) {
+            return BigInteger.valueOf(word >> (8 * (3 - size)));
         }
         else {
-            bn = BigInteger.valueOf((long) mantissa);
-            System.out.println("exponent > 3");
+            return BigInteger.valueOf(word << (8 * (size - 3)));
         }
-
-        if(isNegative) {
-            bn = bn.negate();
-        }
-
-        return bn;
     }
 
     private static int targetToBits(BigInteger target) {

--- a/core/src/test/java/org/bitcoinj/pow/AsertTests.java
+++ b/core/src/test/java/org/bitcoinj/pow/AsertTests.java
@@ -2,6 +2,7 @@ package org.bitcoinj.pow;
 
 import org.bitcoinj.params.AbstractBitcoinNetParams;
 import org.bitcoinj.script.Script;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.math.BigInteger;
@@ -12,17 +13,38 @@ import static org.junit.Assert.assertEquals;
 public class AsertTests {
     @Test
     public void run01() throws Exception {
+        /**
+         * ##   anchor height: 1
+         * ##   anchor ancestor time: 0
+         * ##   anchor nBits: 0x1d00ffff
+         * ##   start height: 2
+         * ##   start time: 1200
+         * ##   iterations: 10
+         * # iteration,height,time,target
+         * 1 2 1200 0x1d00ffff
+         * 2 3 1800 0x1d00ffff
+         * 3 4 2400 0x1d00ffff
+         * 4 5 3000 0x1d00ffff
+         * 5 6 3600 0x1d00ffff
+         * 6 7 4200 0x1d00ffff
+         * 7 8 4800 0x1d00ffff
+         * 8 9 5400 0x1d00ffff
+         * 9 10 6000 0x1d00ffff
+         * 10 11 6600 0x1d00ffff
+         */
         int anchorHeight = 1;
         long anchorTime = 0;
-        int anchorBits = 0x1a2b3c4d;
+        int anchorBits = 0x1d00ffff;
         int startHeight = 2;
-        int iterations = startHeight + 10;
-        for(int x = startHeight; x < iterations; x++) {
-            int evalHeight = x;
+        int startTime = 1200;
+        int iterations = 10;
+        BigInteger expectedValue = BigInteger.valueOf(0x1d00ffffL);
+        for (int i = 0 ; i < iterations; ++i) {
+            int evalHeight = startHeight + i;
             long evalTime = evalHeight * 600;
             BigInteger result = AbstractBitcoinNetParams.computeAsertTarget(anchorBits, anchorTime, anchorHeight, evalTime, evalHeight);
-            int iteration = x - 1;
-            System.out.println(iteration + " " + evalHeight + " " + evalTime + " " + result.toString(16));
+            System.out.println(i + " " + evalHeight + " " + evalTime + " " + result.toString(16));
+            Assert.assertEquals(expectedValue, result);
         }
     }
 }


### PR DESCRIPTION
Run01 of the [test vectors](https://gitlab.com/bitcoin-cash-node/bchn-sw/qa-assets/-/tree/master/test_vectors/aserti3-2d) created by BCHN pass with this change to bitsToTarget.  I believe this is the right direction, but adding the other test vectors first is probably smart before making that conclusion.